### PR TITLE
feat: commit code formatting changes back to branch

### DIFF
--- a/.github/workflows/run_ci.yaml
+++ b/.github/workflows/run_ci.yaml
@@ -83,3 +83,18 @@ jobs:
         
     - name: Run ruff
       run: hatch run code-quality:lint-ci
+        
+    - name: Commit code formatting changes
+      if: github.event_name != 'pull_request'
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          git config --global user.name 'GitHub Action'
+          git config --global user.email 'action@github.com'
+          git add .
+          git commit -m "style: auto-format code with black"
+          git push "https://${{ secrets.GITHUB_PAT }}@github.com/${GITHUB_REPOSITORY}.git" HEAD:${GITHUB_REF#refs/heads/}
+        else
+          echo "No code formatting changes detected, skipping commit"
+        fi
+      env:
+        GITHUB_PAT: ${{ secrets.GITHUB_PAT }}


### PR DESCRIPTION
## Overview
This PR enhances the CI workflow to automatically commit back code formatting changes made by the black formatter to the branch.

## Changes Made
Modified the GitHub workflow `.github/workflows/run_ci.yaml` to add a new step after the code quality checks that:
1. Detects if any files were changed by the Black formatter
2. Commits those changes back to the branch using the provided GITHUB_PAT token
3. Skips this step for pull requests to avoid automatic commits to external contributor branches

## Implementation Details
- Added a conditional check (`if: github.event_name != 'pull_request'`) to only run this step on direct pushes to branches, not on pull requests
- Used git status to detect changes made by the formatting tools
- Configured git with a GitHub Action identity for the commit
- Used GITHUB_PAT environment variable from secrets for authentication when pushing
- Added a clear commit message "style: auto-format code with black" to indicate the automated nature of the changes

## Note About Security
The implementation uses `secrets.GITHUB_PAT` which needs to be added to the repository secrets. This PAT (Personal Access Token) should have write permissions to the repository.

## Testing Considerations
This change can be tested by:
1. Making a commit with code that doesn't meet the Black formatting standards
2. Pushing to a branch
3. Verifying that after the CI workflow runs, a new commit appears with the properly formatted code

## Next Steps
- Add the GITHUB_PAT secret to the repository settings (Settings > Secrets and variables > Actions)