### PR TITLE
feat: only test pipeline serialization on PR and serialize on merge to main

### DIFF
--- a/.github/workflows/run_ci.yaml
+++ b/.github/workflows/run_ci.yaml
@@ -7,8 +7,48 @@ on:
     branches: [ main ]
 
 jobs:
+  validate-pipelines:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install hatch
+
+      - name: Test pipeline serialization
+        id: test_serialization
+        run: |
+          # Import the pipeline module and test that dumps() works without errors
+          python -c "
+          from dc_custom_component.pipelines import dp_pipelines
+          for pipeline_config in dp_pipelines:
+              query_pipeline = pipeline_config['query']
+              if query_pipeline:
+                  print(f'Testing serialization of {pipeline_config[\"workspace\"]}/{pipeline_config[\"name\"]} query pipeline')
+                  yaml_str = query_pipeline.dumps()
+              
+              indexing_pipeline = pipeline_config.get('indexing')
+              if indexing_pipeline:
+                  print(f'Testing serialization of {pipeline_config[\"workspace\"]}/{pipeline_config[\"name\"]} indexing pipeline')
+                  yaml_str = indexing_pipeline.dumps()
+          print('All pipelines serialized successfully!')
+          "
+
   serialize-pipelines:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Overview
This PR modifies the CI workflow to change how pipeline serialization is handled based on the event type:

1. For pull requests: Only test if serialization would work without actually generating YAML files
2. For push to main: Actually serialize the pipelines and save to the dist directory

## Changes Made
- Split the existing `serialize-pipelines` job into two jobs:
  - `validate-pipelines`: Runs on PR events - only tests that pipelines can be serialized using `pipeline.dumps()` without errors
  - `serialize-pipelines`: Runs only when pushing to main - generates and saves the YAML files

## Implementation Details
- Added conditional execution using `if: github.event_name == 'pull_request'` for the validate job
- Added conditional execution using `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` for the serialize job
- Created a Python script in the validate job that imports the pipelines and tests serialization without saving files
- Maintained the original serialization logic for push events to main branch

## Testing Considerations
- The changes can be tested by creating a PR and verifying that the validate-pipelines job runs without generating YAML files
- After merging to main, verify that the serialize-pipelines job runs and generates the YAML files as expected

## Motivation
This change prevents unnecessary serialization and commits during the PR review process while ensuring that pipeline serialization errors are still caught early in the development process.