### PR TITLE
feat: add optional issue_url parameter to PR creator

### DIFF
--- a/src/dc_custom_component/components/github/pr_creator.py
+++ b/src/dc_custom_component/components/github/pr_creator.py
@@ -197,7 +197,7 @@ class GitHubPRCreator:
                     head_branch=head_branch,
                     base_branch=target_base,
                     title=title,
-                    body=body,
+                    body=pr_body,
                     repo=repo_to_use,
                 )
 

--- a/src/dc_custom_component/components/github/pr_creator.py
+++ b/src/dc_custom_component/components/github/pr_creator.py
@@ -150,6 +150,7 @@ class GitHubPRCreator:
         title: str,
         body: str = "",
         repo: Optional[str] = None,
+        issue_url: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Create a pull request on GitHub.
@@ -158,6 +159,7 @@ class GitHubPRCreator:
         :param title: Pull request title
         :param body: Pull request description/body
         :param repo: owner/repo for which to create the pull request
+        :param issue_url: URL to the related issue; if provided, adds a link to the issue in the PR body
         :return: Dictionary containing PR URL, number, and full response data
         """
 

--- a/src/dc_custom_component/components/github/pr_creator.py
+++ b/src/dc_custom_component/components/github/pr_creator.py
@@ -179,6 +179,12 @@ class GitHubPRCreator:
             raise ValueError(
                 "Invalid format for `repo`. The format has to correspond to owner/repo."
             )
+            
+        # If issue_url is provided, add a link to the issue in the PR body
+        pr_body = body
+        if issue_url is not None:
+            issue_link = f"\n\nCloses {issue_url}"
+            pr_body = body + issue_link
 
         attempts = 0
         last_error = None


### PR DESCRIPTION
This PR implements the ability to link a GitHub issue when creating a PR using the `GitHubPRCreator` component.

### Changes Made
- Added an optional `issue_url` parameter to the `run()` method of the `GitHubPRCreator` class
- When `issue_url` is provided, the PR body is automatically augmented with a "Closes {issue_url}" line, which will automatically close the issue when the PR is merged
- Updated the method documentation to include the new parameter

### Implementation Details
- The implementation is minimally invasive, maintaining backward compatibility
- The issue link is added with proper formatting (blank lines separating it from the main PR body)
- Uses GitHub's standard "Closes" keyword to create a proper reference that will automatically close the issue

### Testing Considerations
The changes can be tested by:
1. Creating a PR with no issue_url (original behavior)
2. Creating a PR while passing an issue_url and verifying that the issue reference appears in the PR body
3. Confirming that when a PR with an issue reference is merged, the linked issue is automatically closed

This implementation enhances the usability of the component by allowing direct linkage between PRs and the issues they resolve.