### PR TITLE
feat: add issue_url parameter to PR creator

### DIFF
--- a/src/dc_custom_component/pipelines/github_agent/github_agent.py
+++ b/src/dc_custom_component/pipelines/github_agent/github_agent.py
@@ -144,7 +144,6 @@ def get_agent_pipeline() -> Pipeline:
 
     pp.connect("issue_fetcher.messages", "agent.messages")
     pp.connect("issue_fetcher.branch", "agent.branch")
-    pp.connect("issue_fetcher.url", "agent.issue_url")
     pp.connect("agent.messages", "adapter.messages")
     pp.connect("adapter.output", "builder.replies")
 

--- a/src/dc_custom_component/pipelines/github_agent/github_agent.py
+++ b/src/dc_custom_component/pipelines/github_agent/github_agent.py
@@ -110,7 +110,7 @@ def get_agent_pipeline() -> Pipeline:
         tools=[view_repo_tool, file_editor_tool, create_pr_tool],
         system_prompt=system_prompt,
         exit_conditions=["text", "create_pr"],
-        state_schema={"branch": {"type": str}, "repo": {"type": str}},
+        state_schema={"branch": {"type": str}, "repo": {"type": str}, "issue_url": {"type": str}},
     )
 
     issue_fetcher = FetchIssue(

--- a/src/dc_custom_component/pipelines/github_agent/github_agent.py
+++ b/src/dc_custom_component/pipelines/github_agent/github_agent.py
@@ -143,6 +143,7 @@ def get_agent_pipeline() -> Pipeline:
 
     pp.connect("issue_fetcher.messages", "agent.messages")
     pp.connect("issue_fetcher.branch", "agent.branch")
+    pp.connect("issue_fetcher.url", "agent.issue_url")
     pp.connect("agent.messages", "adapter.messages")
     pp.connect("adapter.output", "builder.replies")
 

--- a/src/dc_custom_component/pipelines/github_agent/github_agent.py
+++ b/src/dc_custom_component/pipelines/github_agent/github_agent.py
@@ -130,6 +130,7 @@ def get_agent_pipeline() -> Pipeline:
                 "query": [
                     "builder.query",
                     "issue_fetcher.url",
+                    "agent.issue_url"
                 ],
             },
             "outputs": {"answers": "builder.answers"},

--- a/src/dc_custom_component/pipelines/github_agent/github_agent.py
+++ b/src/dc_custom_component/pipelines/github_agent/github_agent.py
@@ -83,7 +83,7 @@ def get_agent_pipeline() -> Pipeline:
         component=GitHubPRCreator(),
         name="create_pr",
         description="Creates a pull request with your changes after you've completed your implementation.",
-        inputs_from_state={"branch": "head_branch", "repo": "repo"},
+        inputs_from_state={"branch": "head_branch", "repo": "repo", "issue_url": "issue_url"},
         parameters={
             "type": "object",
             "properties": {


### PR DESCRIPTION
This PR adds the necessary connections to pass the `issue_url` parameter from the pipeline input to the GitHub PR Creator component.

Changes made:
1. Added `issue_url` to the Agent's `state_schema` with type `str`
2. Added `issue_url` to the `inputs_from_state` mapping for the PR creator tool
3. Added a pipeline connection from `issue_fetcher.url` to `agent.issue_url`

These changes ensure that when a GitHub issue URL is provided as input to the pipeline, it will flow through to the PR creator component, which then uses this URL to add a "Closes [issue URL]" reference in the PR description.

This implementation properly connects the query input parameter (which contains the issue URL) to the PR creator tool via the agent's state, ensuring that PRs created by the agent will automatically reference and close the associated GitHub issues.