### PR TITLE
feat: extend AI Issue Processor to trigger on issue comments

### DIFF
--- a/.github/workflows/ai_issue_processor.yaml
+++ b/.github/workflows/ai_issue_processor.yaml
@@ -3,6 +3,8 @@ name: AI Issue Processor
 on:
   issues:
     types: [labeled]
+  issue_comment:
+    types: [created]
 
 jobs:
   process-ai-issue:

--- a/.github/workflows/ai_issue_processor.yaml
+++ b/.github/workflows/ai_issue_processor.yaml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   process-ai-issue:
-    if: ${{ github.event.label.name == 'deepset-ai' }}
+    if: |
+      (github.event_name == 'issues' && github.event.label.name == 'deepset-ai') ||
+      (github.event_name == 'issue_comment' && contains(github.event.issue.labels.*.name, 'deepset-ai'))
     runs-on: ubuntu-latest
     steps:
       - name: Send Issue to deepset AI Platform


### PR DESCRIPTION
This PR extends the AI Issue Processor workflow to trigger not only when an issue is labeled with 'deepset-ai', but also when a comment is added to an issue that already has the 'deepset-ai' label.

## Changes made:

1. Added `issue_comment` event with `created` type to the workflow triggers to listen for new comments
2. Modified the conditional check in the job to handle two scenarios:
   - When an issue is newly labeled with 'deepset-ai'
   - When a comment is added to an issue that already has the 'deepset-ai' label

## Implementation details:

The implementation uses GitHub's conditional workflow syntax to check:
- If the event type is 'issues' and the label name is 'deepset-ai' (original behavior)
- OR if the event type is 'issue_comment' and the issue contains a label named 'deepset-ai'

For issue comments, we use `contains(github.event.issue.labels.*.name, 'deepset-ai')` to check if the 'deepset-ai' label is present in the list of labels attached to the issue being commented on.

## Testing considerations:

This change can be tested by:
1. Adding a comment to an issue labeled with 'deepset-ai' and verifying the workflow runs
2. Confirming the original functionality still works when an issue is labeled with 'deepset-ai'

The rest of the workflow remains unchanged, so the same API call to the deepset AI Platform will be executed in both trigger scenarios.

Closes https://github.com/deepset-ai/dap-github-agent-template/issues/15