### PR TITLE
feat: add Jira issue fetcher component and pipeline

### DIFF
--- a/src/dc_custom_component/components/jira/__init__.py
+++ b/src/dc_custom_component/components/jira/__init__.py
@@ -1,0 +1,3 @@
+from .jira_issue_viewer import JiraIssueViewer
+
+__all__ = ["JiraIssueViewer"]

--- a/src/dc_custom_component/components/jira/__init__.py
+++ b/src/dc_custom_component/components/jira/__init__.py
@@ -1,3 +1,4 @@
 from .jira_issue_viewer import JiraIssueViewer
+from .fetch_issues import FetchJiraIssue
 
-__all__ = ["JiraIssueViewer"]
+__all__ = ["JiraIssueViewer", "FetchJiraIssue"]

--- a/src/dc_custom_component/components/jira/fetch_issues.py
+++ b/src/dc_custom_component/components/jira/fetch_issues.py
@@ -1,0 +1,92 @@
+from typing import Any, Optional
+
+
+from haystack import (
+    SuperComponent,
+    component,
+    Pipeline,
+    default_from_dict,
+    default_to_dict,
+)
+from haystack.utils import Secret, deserialize_secrets_inplace
+
+from dc_custom_component.components.jira.jira_issue_viewer import JiraIssueViewer
+from dc_custom_component.components.github.documents_to_messages import (
+    DocumentToChatMessageConverter,
+)
+from dc_custom_component.components.github.branch_creator import GithubBranchCreator
+
+
+@component
+class FetchJiraIssue(SuperComponent):
+    def __init__(
+        self,
+        jira_token: Secret = Secret.from_env_var("JIRA_API_TOKEN", strict=False),
+        jira_email: Secret = Secret.from_env_var("JIRA_EMAIL", strict=False),
+        jira_base_url: Optional[str] = None,
+        github_token: Secret = Secret.from_env_var("GITHUB_TOKEN", strict=False),
+        assistant_pattern: Optional[str] = None,
+        strip_role_prefix: bool = True,
+    ):
+        self.jira_token = jira_token
+        self.jira_email = jira_email
+        self.jira_base_url = jira_base_url
+        self.github_token = github_token
+        self.assistant_pattern = assistant_pattern
+        self.strip_role_prefix = strip_role_prefix
+
+        fetcher = JiraIssueViewer(
+            jira_token=self.jira_token,
+            jira_email=self.jira_email,
+            jira_base_url=self.jira_base_url
+        )
+        converter = DocumentToChatMessageConverter(
+            assistant_pattern=self.assistant_pattern,
+            strip_role_prefix=self.strip_role_prefix,
+        )
+        creator = GithubBranchCreator(
+            github_token=self.github_token, fail_if_exists=False
+        )
+
+        pp = Pipeline()
+        pp.add_component("branch_creator", creator)
+        pp.add_component("fetcher", fetcher)
+        pp.add_component("converter", converter)
+
+        pp.connect("fetcher.documents", "converter.documents")
+
+        super(FetchJiraIssue, self).__init__(
+            pipeline=pp,
+            output_mapping={
+                "branch_creator.branch_name": "branch",
+                "converter.messages": "messages",
+            },
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            jira_token=self.jira_token.to_dict() if self.jira_token else None,
+            jira_email=self.jira_email.to_dict() if self.jira_email else None,
+            jira_base_url=self.jira_base_url,
+            github_token=self.github_token.to_dict() if self.github_token else None,
+            assistant_pattern=self.assistant_pattern,
+            strip_role_prefix=self.strip_role_prefix,
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "FetchJiraIssue":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["jira_token", "jira_email", "github_token"])
+        return default_from_dict(cls, data)

--- a/src/dc_custom_component/components/jira/jira_issue_viewer.py
+++ b/src/dc_custom_component/components/jira/jira_issue_viewer.py
@@ -1,0 +1,278 @@
+import re
+from typing import Any, Dict, List, Optional
+
+import requests
+from haystack import Document, component, default_from_dict, default_to_dict, logging
+from haystack.utils import deserialize_secrets_inplace
+from haystack.utils.auth import Secret
+
+logger = logging.getLogger(__name__)
+
+
+@component
+class JiraIssueViewer:
+    """
+    Fetches and parses Jira issues into Haystack documents.
+
+    The component takes a Jira issue URL and returns a list of documents where:
+    - First document contains the main issue content
+    - Subsequent documents contain the issue comments
+
+    ### Usage example
+    ```python
+    from dc_custom_component.components.jira import JiraIssueViewer
+
+    viewer = JiraIssueViewer(jira_token=Secret.from_env_var("JIRA_API_TOKEN"), jira_email=Secret.from_token("user@example.com"))
+    docs = viewer.run(
+        url="https://your-domain.atlassian.net/browse/PROJECT-123"
+    )["documents"]
+
+    assert len(docs) >= 1  # At least the main issue
+    assert docs[0].meta["type"] == "issue"
+    ```
+    """
+
+    def __init__(
+        self,
+        jira_token: Optional[Secret] = None,
+        jira_email: Optional[Secret] = None,
+        jira_base_url: Optional[str] = None,
+        raise_on_failure: bool = True,
+        retry_attempts: int = 2,
+    ):
+        """
+        Initialize the component.
+
+        :param jira_token: Jira API token for authentication as a Secret
+        :param jira_email: Jira account email for authentication as a Secret
+        :param jira_base_url: Base URL for Jira API (optional, extracted from issue URL if not provided)
+        :param raise_on_failure: If True, raises exceptions on API errors
+        :param retry_attempts: Number of retry attempts for failed requests
+        """
+        self.jira_token = jira_token
+        self.jira_email = jira_email
+        self.jira_base_url = jira_base_url
+        self.raise_on_failure = raise_on_failure
+        self.retry_attempts = retry_attempts
+
+        # Only set the basic headers during initialization
+        self.headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+
+    def _get_request_auth(self) -> Optional[tuple]:
+        """
+        Get authentication tuple for the request.
+
+        :return: Tuple of (email, token) if credentials are provided, None otherwise
+        """
+        if self.jira_email and self.jira_token:
+            return (self.jira_email.resolve_value(), self.jira_token.resolve_value())
+        return None
+
+    def _parse_jira_url(self, url: str) -> tuple[str, str]:
+        """
+        Parse Jira URL into base URL and issue key.
+
+        :param url: Jira issue URL
+        :return: Tuple of (base_url, issue_key)
+        :raises ValueError: If URL format is invalid
+        """
+        # Pattern for Jira Cloud URL: https://your-domain.atlassian.net/browse/PROJECT-123
+        pattern = r"https?://([^/]+)/browse/([^/]+)"
+        match = re.match(pattern, url)
+        if not match:
+            raise ValueError(f"Invalid Jira issue URL format: {url}")
+
+        domain, issue_key = match.groups()
+        base_url = f"https://{domain}"
+        
+        return base_url, issue_key
+
+    def _fetch_issue(self, base_url: str, issue_key: str) -> Any:
+        """
+        Fetch issue data from Jira API.
+
+        :param base_url: Jira instance base URL
+        :param issue_key: Issue key (e.g., PROJECT-123)
+        :return: Issue data dictionary
+        """
+        url = f"{base_url}/rest/api/3/issue/{issue_key}"
+        response = requests.get(url, auth=self._get_request_auth(), headers=self.headers)
+        response.raise_for_status()
+        return response.json()
+
+    def _fetch_comments(self, base_url: str, issue_key: str) -> Any:
+        """
+        Fetch issue comments from Jira API.
+
+        :param base_url: Jira instance base URL
+        :param issue_key: Issue key (e.g., PROJECT-123)
+        :return: List of comment dictionaries
+        """
+        url = f"{base_url}/rest/api/3/issue/{issue_key}/comment"
+        response = requests.get(url, auth=self._get_request_auth(), headers=self.headers)
+        response.raise_for_status()
+        return response.json().get("comments", [])
+
+    def _extract_text_from_jira_content(self, content_obj: Any) -> str:
+        """
+        Extract plain text from Jira's Atlassian Document Format (ADF).
+        
+        This is a simplified extractor that tries to get text content from
+        Jira's complex document format.
+        
+        :param content_obj: The content object from Jira API
+        :return: Extracted plain text
+        """
+        if not content_obj or "content" not in content_obj:
+            return ""
+            
+        text_parts = []
+        
+        def extract_text(node):
+            if isinstance(node, dict):
+                if node.get("type") == "text" and "text" in node:
+                    text_parts.append(node["text"])
+                    
+                # Handle paragraphs, headings, lists, etc.
+                if "content" in node and isinstance(node["content"], list):
+                    for item in node["content"]:
+                        extract_text(item)
+            elif isinstance(node, list):
+                for item in node:
+                    extract_text(item)
+        
+        extract_text(content_obj)
+        return "\n".join(text_parts)
+
+    def _create_issue_document(self, issue_data: dict, base_url: str) -> Document:
+        """
+        Create a Document from issue data.
+
+        :param issue_data: Issue data from Jira API
+        :param base_url: Jira instance base URL
+        :return: Haystack Document
+        """
+        # Extract description - handle both string and ADF formats
+        description = issue_data.get("fields", {}).get("description", "")
+        if isinstance(description, dict):
+            description = self._extract_text_from_jira_content(description)
+            
+        issue_key = issue_data.get("key")
+        issue_fields = issue_data.get("fields", {})
+        
+        return Document(
+            content=description,
+            meta={
+                "type": "issue",
+                "key": issue_key,
+                "title": issue_fields.get("summary", ""),
+                "status": issue_fields.get("status", {}).get("name", ""),
+                "created_at": issue_fields.get("created", ""),
+                "updated_at": issue_fields.get("updated", ""),
+                "author": issue_fields.get("reporter", {}).get("displayName", ""),
+                "assignee": issue_fields.get("assignee", {}).get("displayName", ""),
+                "url": f"{base_url}/browse/{issue_key}",
+            },
+        )
+
+    def _create_comment_document(
+        self, comment_data: dict, issue_key: str, base_url: str
+    ) -> Document:
+        """
+        Create a Document from comment data.
+
+        :param comment_data: Comment data from Jira API
+        :param issue_key: Parent issue key
+        :param base_url: Jira instance base URL
+        :return: Haystack Document
+        """
+        # Extract body - handle both string and ADF formats
+        body = comment_data.get("body", "")
+        if isinstance(body, dict):
+            body = self._extract_text_from_jira_content(body)
+            
+        return Document(
+            content=body,
+            meta={
+                "type": "comment",
+                "issue_key": issue_key,
+                "created_at": comment_data.get("created", ""),
+                "updated_at": comment_data.get("updated", ""),
+                "author": comment_data.get("author", {}).get("displayName", ""),
+                "url": f"{base_url}/browse/{issue_key}?focusedCommentId={comment_data.get('id', '')}",
+            },
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Serialize the component to a dictionary.
+
+        :returns: Dictionary with serialized data.
+        """
+        return default_to_dict(
+            self,
+            jira_token=self.jira_token.to_dict() if self.jira_token else None,
+            jira_email=self.jira_email.to_dict() if self.jira_email else None,
+            jira_base_url=self.jira_base_url,
+            raise_on_failure=self.raise_on_failure,
+            retry_attempts=self.retry_attempts,
+        )
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "JiraIssueViewer":
+        """
+        Deserialize the component from a dictionary.
+
+        :param data: Dictionary to deserialize from.
+        :returns: Deserialized component.
+        """
+        init_params = data["init_parameters"]
+        deserialize_secrets_inplace(init_params, keys=["jira_token", "jira_email"])
+        return default_from_dict(cls, data)
+
+    @component.output_types(documents=List[Document])
+    def run(self, url: str) -> dict:
+        """
+        Process a Jira issue URL and return documents.
+
+        :param url: Jira issue URL
+        :return: Dictionary containing list of documents
+        """
+        try:
+            # Extract base URL and issue key from URL
+            base_url, issue_key = self._parse_jira_url(url)
+            
+            # Use provided base URL if available
+            base_url = self.jira_base_url or base_url
+
+            # Fetch issue data
+            issue_data = self._fetch_issue(base_url, issue_key)
+            documents = [self._create_issue_document(issue_data, base_url)]
+
+            # Fetch and process comments
+            comments = self._fetch_comments(base_url, issue_key)
+            documents.extend(
+                self._create_comment_document(comment, issue_key, base_url)
+                for comment in comments
+            )
+
+            return {"documents": documents}
+
+        except Exception as e:
+            if self.raise_on_failure:
+                raise
+
+            error_message = f"Error processing Jira issue {url}: {str(e)}"
+            logger.warning(error_message)
+            error_doc = Document(
+                content=error_message,
+                meta={
+                    "error": True,
+                    "type": "error",
+                    "url": url,
+                },
+            )
+            return {"documents": [error_doc]}

--- a/src/dc_custom_component/pipelines/__init__.py
+++ b/src/dc_custom_component/pipelines/__init__.py
@@ -1,12 +1,20 @@
-from dc_custom_component.pipelines.github_agent.github_agent import get_agent_pipeline
+from dc_custom_component.pipelines.github_agent.github_agent import get_agent_pipeline as get_github_agent_pipeline
+from dc_custom_component.pipelines.jira_agent.jira_agent import get_agent_pipeline as get_jira_agent_pipeline
 
 
 github_agent_config = {
     "name": "github-agent-claude",
     "workspace": "default",
-    "query": get_agent_pipeline(),
+    "query": get_github_agent_pipeline(),
+}
+
+jira_agent_config = {
+    "name": "jira-agent-claude",
+    "workspace": "default",
+    "query": get_jira_agent_pipeline(),
 }
 
 dp_pipelines = [
     github_agent_config,
+    jira_agent_config,
 ]

--- a/src/dc_custom_component/pipelines/jira_agent/__init__.py
+++ b/src/dc_custom_component/pipelines/jira_agent/__init__.py
@@ -1,0 +1,3 @@
+from .jira_agent import get_agent_pipeline
+
+__all__ = ["get_agent_pipeline"]

--- a/src/dc_custom_component/pipelines/jira_agent/jira_agent.py
+++ b/src/dc_custom_component/pipelines/jira_agent/jira_agent.py
@@ -1,0 +1,154 @@
+from haystack import Pipeline
+
+from haystack.components.agents import Agent
+from haystack.components.builders import AnswerBuilder
+from haystack.components.converters import OutputAdapter
+from haystack.tools import ComponentTool
+from haystack.utils import Secret
+
+from haystack_integrations.components.generators.anthropic.chat.chat_generator import (
+    AnthropicChatGenerator,
+)
+
+from dc_custom_component.components.jira.fetch_issues import FetchJiraIssue
+from dc_custom_component.components.github.read_contents import GithubContentViewer
+from dc_custom_component.components.github.file_editor import GithubFileEditor
+from dc_custom_component.components.github.pr_creator import GitHubPRCreator
+
+from dc_custom_component.pipelines.github_agent.system_prompt import system_prompt
+
+
+def get_agent_pipeline() -> Pipeline:
+    view_repo_tool = ComponentTool(
+        component=GithubContentViewer(raise_on_failure=False),
+        name="view_repository",
+        description="Use to explore the contents of the repository.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The path to the directory or file to view (empty string for root)",
+                }
+            },
+            "required": ["path"],
+        },
+    )
+
+    file_editor_tool = ComponentTool(
+        component=GithubFileEditor(raise_on_failure=False),
+        name="file_editor",
+        description="Use the file editor to edit an existing file in the repository.",
+        parameters={
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "description": "The action to perform. One of: 'edit', 'create', 'delete', or 'undo'",
+                    "enum": ["edit", "create", "delete", "undo"],
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "The details for the command",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "The full path to the file (required for edit, create, and delete commands)",
+                        },
+                        "original": {
+                            "type": "string",
+                            "description": "The exact text to replace (minimum 2 consecutive lines; required for edit command)",
+                        },
+                        "replacement": {
+                            "type": "string",
+                            "description": "The new text to insert (required for edit command)",
+                        },
+                        "content": {
+                            "type": "string",
+                            "description": "The content of the file (required for create command)",
+                        },
+                        "message": {
+                            "type": "string",
+                            "description": "A descriptive commit message using conventional commit style (required for all commands)",
+                        },
+                    },
+                    "required": ["message"],
+                },
+            },
+            "required": ["command", "payload"],
+        },
+    )
+
+    create_pr_tool = ComponentTool(
+        component=GitHubPRCreator(),
+        name="create_pr",
+        description="Creates a pull request with your changes after you've completed your implementation.",
+        inputs_from_state={
+            "branch": "head_branch",
+            "repo": "repo",
+            "issue_url": "issue_url",
+        },
+        parameters={
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "description": "A concise, descriptive title for the pull request following conventional commit style",
+                },
+                "body": {
+                    "type": "string",
+                    "description": "A detailed description of the changes made, explaining the approach and implementation details",
+                },
+            },
+            "required": ["title", "body"],
+        },
+    )
+
+    chat_generator = AnthropicChatGenerator(
+        model="claude-3-7-sonnet-latest",
+        generation_kwargs={"max_tokens": 8000},
+        api_key=Secret.from_env_var("ANTHROPIC_API_KEY", strict=False),
+    )
+    agent = Agent(
+        chat_generator=chat_generator,
+        tools=[view_repo_tool, file_editor_tool, create_pr_tool],
+        system_prompt=system_prompt,
+        exit_conditions=["text", "create_pr"],
+        state_schema={
+            "branch": {"type": str},
+            "repo": {"type": str},
+            "issue_url": {"type": str},
+        },
+    )
+
+    issue_fetcher = FetchJiraIssue(
+        assistant_pattern="@agent-message", strip_role_prefix=True
+    )
+
+    adapter = OutputAdapter(
+        template="{{['successfully finished in ' ~ messages|length ~ ' steps']}}",
+        output_type=list[str],
+    )
+
+    builder = AnswerBuilder()
+
+    pp = Pipeline(
+        metadata={
+            "inputs": {
+                "query": ["builder.query", "issue_fetcher.url", "agent.issue_url"],
+            },
+            "outputs": {"answers": "builder.answers"},
+        }
+    )
+
+    pp.add_component("agent", agent)
+    pp.add_component("issue_fetcher", issue_fetcher)
+    pp.add_component("adapter", adapter)
+    pp.add_component("builder", builder)
+
+    pp.connect("issue_fetcher.messages", "agent.messages")
+    pp.connect("issue_fetcher.branch", "agent.branch")
+    pp.connect("agent.messages", "adapter.messages")
+    pp.connect("adapter.output", "builder.replies")
+
+    return pp

--- a/tests/components/jira/test_fetch_jira_issue.py
+++ b/tests/components/jira/test_fetch_jira_issue.py
@@ -1,0 +1,131 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from haystack import Pipeline
+from haystack.dataclasses import ChatMessage
+from haystack.utils import Secret
+
+from dc_custom_component.components.jira import FetchJiraIssue
+from dc_custom_component.components.jira.jira_issue_viewer import JiraIssueViewer
+from dc_custom_component.components.github.documents_to_messages import DocumentToChatMessageConverter
+from dc_custom_component.components.github.branch_creator import GithubBranchCreator
+
+
+@pytest.fixture
+def mock_components():
+    # Create mocks for the individual components
+    mock_jira_viewer = MagicMock()
+    mock_converter = MagicMock()
+    mock_branch_creator = MagicMock()
+    
+    # Configure the mocks
+    documents = [MagicMock(), MagicMock()]  # Mock documents
+    messages = [ChatMessage.from_user("Test message")]  # Sample messages
+    
+    mock_jira_viewer.run.return_value = {"documents": documents}
+    mock_converter.run.return_value = {"messages": messages}
+    mock_branch_creator.run.return_value = {"branch_name": "test-branch"}
+    
+    return {
+        "jira_viewer": mock_jira_viewer,
+        "converter": mock_converter,
+        "branch_creator": mock_branch_creator,
+        "expected_documents": documents,
+        "expected_messages": messages
+    }
+
+
+@patch("dc_custom_component.components.jira.fetch_issues.JiraIssueViewer")
+@patch("dc_custom_component.components.jira.fetch_issues.DocumentToChatMessageConverter")
+@patch("dc_custom_component.components.jira.fetch_issues.GithubBranchCreator")
+@patch("dc_custom_component.components.jira.fetch_issues.Pipeline")
+def test_fetch_jira_issue_init(mock_pipeline_class, mock_branch_creator_class, 
+                              mock_converter_class, mock_jira_viewer_class):
+    # Setup mocks
+    mock_pipeline = MagicMock()
+    mock_pipeline_class.return_value = mock_pipeline
+    
+    # Create the component
+    fetcher = FetchJiraIssue(
+        jira_token=Secret.from_token("test-jira-token"),
+        jira_email=Secret.from_token("test@example.com"),
+        jira_base_url="https://test.atlassian.net",
+        github_token=Secret.from_token("test-github-token"),
+        assistant_pattern="test-pattern",
+        strip_role_prefix=True
+    )
+    
+    # Assertions
+    assert mock_jira_viewer_class.called
+    jira_viewer_call = mock_jira_viewer_class.call_args[1]
+    assert jira_viewer_call["jira_token"].resolve_value() == "test-jira-token"
+    assert jira_viewer_call["jira_email"].resolve_value() == "test@example.com"
+    assert jira_viewer_call["jira_base_url"] == "https://test.atlassian.net"
+    
+    assert mock_converter_class.called
+    converter_call = mock_converter_class.call_args[1]
+    assert converter_call["assistant_pattern"] == "test-pattern"
+    assert converter_call["strip_role_prefix"] is True
+    
+    assert mock_branch_creator_class.called
+    branch_creator_call = mock_branch_creator_class.call_args[1]
+    assert branch_creator_call["github_token"].resolve_value() == "test-github-token"
+    assert branch_creator_call["fail_if_exists"] is False
+    
+    # Check pipeline setup
+    assert mock_pipeline.add_component.call_count == 3
+    assert mock_pipeline.connect.called
+
+
+def test_fetch_jira_issue_run(mock_components):
+    # Create a real Pipeline with mocked components
+    pp = Pipeline()
+    
+    pp.add_component("branch_creator", mock_components["branch_creator"])
+    pp.add_component("fetcher", mock_components["jira_viewer"])
+    pp.add_component("converter", mock_components["converter"])
+    
+    pp.connect("fetcher.documents", "converter.documents")
+    
+    # Create FetchJiraIssue instance with our pipeline
+    fetcher = FetchJiraIssue()
+    fetcher._wrapped_pipeline = pp
+    
+    # Run the component
+    result = fetcher.run(url="https://test.atlassian.net/browse/TEST-123")
+    
+    # Check results
+    assert "branch" in result
+    assert "messages" in result
+    assert result["branch"] == "test-branch"
+    assert result["messages"] == mock_components["expected_messages"]
+    
+    # Verify component calls
+    mock_components["jira_viewer"].run.assert_called_once()
+    mock_components["converter"].run.assert_called_once_with(
+        documents=mock_components["expected_documents"]
+    )
+
+
+def test_fetch_jira_issue_serialization():
+    # Test serialization/deserialization
+    original = FetchJiraIssue(
+        jira_token=Secret.from_token("test-jira-token"),
+        jira_email=Secret.from_token("test@example.com"),
+        jira_base_url="https://test.atlassian.net",
+        github_token=Secret.from_token("test-github-token"),
+        assistant_pattern="test-pattern",
+        strip_role_prefix=True
+    )
+    
+    # Convert to dict and back
+    serialized = original.to_dict()
+    deserialized = FetchJiraIssue.from_dict(serialized)
+    
+    # Check that attributes are preserved
+    assert deserialized.jira_token.resolve_value() == "test-jira-token"
+    assert deserialized.jira_email.resolve_value() == "test@example.com"
+    assert deserialized.jira_base_url == "https://test.atlassian.net"
+    assert deserialized.github_token.resolve_value() == "test-github-token"
+    assert deserialized.assistant_pattern == "test-pattern"
+    assert deserialized.strip_role_prefix is True

--- a/tests/components/jira/test_jira_issue_viewer.py
+++ b/tests/components/jira/test_jira_issue_viewer.py
@@ -1,0 +1,192 @@
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import responses
+from haystack.dataclasses import Document
+from haystack.utils import Secret
+
+from dc_custom_component.components.jira import JiraIssueViewer
+
+
+@pytest.fixture
+def jira_issue_data():
+    # Sample Jira issue data in API format
+    return {
+        "id": "10000",
+        "key": "TEST-123", 
+        "fields": {
+            "summary": "Test issue",
+            "description": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "This is a test issue description."
+                            }
+                        ]
+                    }
+                ]
+            },
+            "status": {"name": "Open"},
+            "created": "2023-01-01T12:00:00.000Z",
+            "updated": "2023-01-02T12:00:00.000Z",
+            "reporter": {"displayName": "Test User"},
+            "assignee": {"displayName": "Assigned User"}
+        }
+    }
+
+
+@pytest.fixture
+def jira_comments_data():
+    # Sample Jira comments data in API format
+    return {
+        "comments": [
+            {
+                "id": "1001",
+                "body": {
+                    "type": "doc",
+                    "version": 1,
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "This is a comment."
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "author": {"displayName": "Comment Author"},
+                "created": "2023-01-03T12:00:00.000Z",
+                "updated": "2023-01-03T12:00:00.000Z"
+            }
+        ]
+    }
+
+
+@responses.activate
+def test_jira_issue_viewer_run(jira_issue_data, jira_comments_data):
+    # Setup mocked responses
+    jira_domain = "test-domain.atlassian.net"
+    issue_key = "TEST-123"
+    
+    # Mock the issue API endpoint
+    responses.add(
+        responses.GET,
+        f"https://{jira_domain}/rest/api/3/issue/{issue_key}",
+        json=jira_issue_data,
+        status=200
+    )
+    
+    # Mock the comments API endpoint
+    responses.add(
+        responses.GET,
+        f"https://{jira_domain}/rest/api/3/issue/{issue_key}/comment",
+        json=jira_comments_data,
+        status=200
+    )
+    
+    # Create the component
+    viewer = JiraIssueViewer(
+        jira_token=Secret.from_token("test-token"),
+        jira_email=Secret.from_token("test@example.com")
+    )
+    
+    # Call the component
+    result = viewer.run(url=f"https://{jira_domain}/browse/{issue_key}")
+    
+    # Assertions
+    assert "documents" in result
+    documents = result["documents"]
+    assert len(documents) == 2
+    
+    # Check issue document
+    issue_doc = documents[0]
+    assert issue_doc.content == "This is a test issue description."
+    assert issue_doc.meta["type"] == "issue"
+    assert issue_doc.meta["key"] == "TEST-123"
+    assert issue_doc.meta["title"] == "Test issue"
+    
+    # Check comment document
+    comment_doc = documents[1]
+    assert comment_doc.content == "This is a comment."
+    assert comment_doc.meta["type"] == "comment"
+    assert comment_doc.meta["issue_key"] == "TEST-123"
+    assert comment_doc.meta["author"] == "Comment Author"
+
+
+def test_parse_jira_url():
+    viewer = JiraIssueViewer()
+    base_url, issue_key = viewer._parse_jira_url("https://test-domain.atlassian.net/browse/TEST-123")
+    
+    assert base_url == "https://test-domain.atlassian.net"
+    assert issue_key == "TEST-123"
+    
+    # Test invalid URL
+    with pytest.raises(ValueError):
+        viewer._parse_jira_url("https://invalid-url.com/wrong-format")
+
+
+@responses.activate
+def test_error_handling():
+    # Setup a failing response
+    jira_domain = "test-domain.atlassian.net"
+    issue_key = "TEST-123"
+    
+    responses.add(
+        responses.GET,
+        f"https://{jira_domain}/rest/api/3/issue/{issue_key}",
+        json={"error": "Not found"},
+        status=404
+    )
+    
+    # Test with raise_on_failure=False
+    viewer = JiraIssueViewer(raise_on_failure=False)
+    result = viewer.run(url=f"https://{jira_domain}/browse/{issue_key}")
+    
+    assert "documents" in result
+    assert len(result["documents"]) == 1
+    assert result["documents"][0].meta["error"] is True
+    
+    # Test with raise_on_failure=True
+    viewer = JiraIssueViewer(raise_on_failure=True)
+    with pytest.raises(Exception):
+        viewer.run(url=f"https://{jira_domain}/browse/{issue_key}")
+
+
+def test_extract_text_from_jira_content():
+    viewer = JiraIssueViewer()
+    
+    # Test with complex ADF content
+    adf_content = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "Line 1"}
+                ]
+            },
+            {
+                "type": "paragraph",
+                "content": [
+                    {"type": "text", "text": "Line 2"}
+                ]
+            }
+        ]
+    }
+    
+    extracted_text = viewer._extract_text_from_jira_content(adf_content)
+    assert "Line 1\nLine 2" == extracted_text
+    
+    # Test with empty content
+    assert viewer._extract_text_from_jira_content({}) == ""
+    assert viewer._extract_text_from_jira_content(None) == ""


### PR DESCRIPTION
## Overview

This PR adds support for fetching issues from Jira to complement the existing GitHub issue fetcher functionality. It creates a similar Haystack component structure that integrates with Jira's REST API to fetch issue data and convert it to chat messages for the agent.

## Features Added

1. **JiraIssueViewer Component**: Fetches Jira issues and comments, handling Jira's Atlassian Document Format (ADF) content structure
2. **FetchJiraIssue SuperComponent**: Combines issue fetching, document conversion, and branch creation like the GitHub counterpart
3. **Jira Agent Pipeline**: Parallels the GitHub agent pipeline but uses the Jira components

## Implementation Details

### Jira API Integration
- Implemented authentication using Jira API token and email
- Added support for parsing Jira Cloud URLs (e.g., `https://your-domain.atlassian.net/browse/PROJECT-123`)
- Created helper methods to extract readable text from Jira's complex document format (ADF)

### Component Structure
- Created components with the same interfaces as their GitHub counterparts for consistency
- Maintained the same document/message conversion process for seamless integration

### Pipeline Configuration
- Added a Jira agent pipeline that mirrors the GitHub agent pipeline
- Updated pipelines package exports to include both agent types
- Reused the system prompt from the GitHub agent since the agent behavior is identical

### Tests
- Added comprehensive unit tests for the new components
- Included mocking of Jira API responses for testing

## Testing Considerations

The implementation has been tested with unit tests that verify:
- Correct parsing of Jira URLs
- Proper extraction of text from Jira's document format
- Error handling for API issues
- Component integration and serialization

Manual testing should verify:
1. Authentication with real Jira credentials
2. Fetching real issues from Jira instances
3. End-to-end pipeline execution

## Environment Requirements

To use this feature, users will need to set the following environment variables:
- `JIRA_API_TOKEN`: A valid Jira API token
- `JIRA_EMAIL`: The email associated with the Jira account

Closes https://github.com/deepset-ai/dap-github-agent-template/issues/19